### PR TITLE
Feat: The summoner info is shown.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "cSpell.words": [
+        "flowbite",
+        "puuid"
+    ]
+}

--- a/src/lib/api/league.ts
+++ b/src/lib/api/league.ts
@@ -1,0 +1,34 @@
+import { env } from '$env/dynamic/public';
+import type LeagueEntryDto from '$lib/interfaces/LeagueEntryDto';
+import type RegionId from '$lib/interfaces/RegionId';
+import { writable } from 'svelte/store';
+
+export interface FetchLeague {
+  regionId: RegionId;
+  summonerId: string;
+}
+
+const SERVER = env.PUBLIC_SERVER;
+const endPoint = 'riot/lol/league/';
+
+export const useFetchLeague = (params: FetchLeague) => {
+  const data = writable<LeagueEntryDto | null>(null);
+  const error = writable<unknown | null>(null);
+  const isLoading = writable(false);
+
+  const fetchData = async () => {
+    isLoading.set(true);
+    const completeEndPoint = SERVER + endPoint + params.regionId + '/' + params.summonerId;
+    try {
+      const results = await (await fetch(completeEndPoint)).json();
+      data.set(results);
+    } catch (err) {
+      error.set(err);
+    }
+    isLoading.set(false);
+  };
+
+  fetchData();
+
+  return { isLoading, error, data };
+};

--- a/src/lib/api/summoner.ts
+++ b/src/lib/api/summoner.ts
@@ -1,0 +1,34 @@
+import { env } from '$env/dynamic/public';
+import type RegionId from '$lib/interfaces/RegionId';
+import type SummonerDto from '$lib/interfaces/SummonerDto';
+import { writable } from 'svelte/store';
+
+export interface FetchSummoner {
+  regionId: RegionId;
+  puuid: string;
+}
+
+const SERVER = env.PUBLIC_SERVER;
+const endPoint = 'riot/lol/summoners/';
+
+export const useFetchSummoner = (params: FetchSummoner) => {
+  const data = writable<SummonerDto | null>(null);
+  const error = writable<unknown | null>(null);
+  const isLoading = writable(false);
+
+  const fetchData = async () => {
+    isLoading.set(true);
+    const completeEndPoint = SERVER + endPoint + params.regionId + '/' + params.puuid;
+    try {
+      const results = await (await fetch(completeEndPoint)).json();
+      data.set(results);
+    } catch (err) {
+      error.set(err);
+    }
+    isLoading.set(false);
+  };
+
+  fetchData();
+
+  return { isLoading, error, data };
+};

--- a/src/lib/components/SearchBar.svelte
+++ b/src/lib/components/SearchBar.svelte
@@ -1,12 +1,10 @@
 <script lang="ts">
-  import { goto } from '$app/navigation';
+  import { goto, pushState } from '$app/navigation';
   import Region from '$lib/interfaces/Region';
-  import { Search, Button } from 'flowbite-svelte';
+  import { Search, Button, Heading } from 'flowbite-svelte';
   import { onMount } from 'svelte';
 
   let inputValue: string = '';
-
-  onMount(() => {});
 
   const searchAccount = (event: MouseEvent) => {
     const input = inputValue.split('#');
@@ -17,6 +15,11 @@
   };
 </script>
 
-<Search bind:value={inputValue}>
-  <Button on:click={searchAccount}>Search</Button>
-</Search>
+<div class="flex flex-col gap-4 w-full max-w-96 p-3">
+  <label for="search-input">
+    <Heading tag="h3" class="text-center">Search Summoner</Heading>
+  </label>
+  <Search bind:value={inputValue} id="search-input" placeholder="example: khaski#jp1">
+    <Button on:click={searchAccount}>Search</Button>
+  </Search>
+</div>

--- a/src/lib/components/SummonerCard.svelte
+++ b/src/lib/components/SummonerCard.svelte
@@ -1,0 +1,41 @@
+<script lang="ts">
+  import { useFetchSummoner } from '$lib/api/summoner';
+  import type AccountDto from '$lib/interfaces/AccountDto';
+  import RegionId from '$lib/interfaces/RegionId';
+  import type SummonerDto from '$lib/interfaces/SummonerDto';
+  import { Card, Avatar } from 'flowbite-svelte';
+  import { onMount } from 'svelte';
+  import { type Writable } from 'svelte/store';
+
+  const iconUrl = 'https://raw.communitydragon.org/latest/game/assets/ux/summonericons/profileicon';
+  const iconFormat = '.png';
+
+  export let account: AccountDto;
+  export let setSummoner: (param: Writable<SummonerDto | null>) => void;
+
+  let summoner: Writable<SummonerDto | null>;
+
+  onMount(() => {
+    const { isLoading, error, data } = useFetchSummoner({
+      regionId: RegionId.JP1.toLowerCase() as RegionId,
+      puuid: account.puuid
+    });
+
+    summoner = data;
+    setSummoner(summoner);
+  });
+</script>
+
+<Card padding="md">
+  <div class="flex flex-col items-center pb-4">
+    {#if $summoner}
+      <Avatar size="lg" src={iconUrl + $summoner.profileIconId + iconFormat} />
+    {/if}
+    <h5 class="mb-1 text-xl font-medium text-gray-900 dark:text-white">
+      {account.gameName + '#' + account.tagLine}
+    </h5>
+    {#if $summoner}
+      <span class="text-sm text-gray-500 dark:text-gray-400">LVL {$summoner.summonerLevel}</span>
+    {/if}
+  </div>
+</Card>

--- a/src/lib/components/SummonerCardElo.svelte
+++ b/src/lib/components/SummonerCardElo.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+  import { useFetchLeague } from '$lib/api/league';
+  import type LeagueEntryDto from '$lib/interfaces/LeagueEntryDto';
+  import RegionId from '$lib/interfaces/RegionId';
+  import type SummonerDto from '$lib/interfaces/SummonerDto';
+  import { Avatar, Card } from 'flowbite-svelte';
+  import { onMount } from 'svelte';
+  import type { Writable } from 'svelte/store';
+
+  const rankImage =
+    'https://raw.communitydragon.org/latest/plugins/rcp-fe-lol-shared-components/global/default/images/';
+  const rankImageFormat = '.png';
+
+  export let summoner: SummonerDto;
+  export let setLeague: (param: Writable<LeagueEntryDto | null>) => void;
+
+  let league: Writable<LeagueEntryDto | null>;
+
+  onMount(() => {
+    const { isLoading, error, data } = useFetchLeague({
+      regionId: RegionId.JP1.toLowerCase() as RegionId,
+      summonerId: summoner.id
+    });
+
+    league = data;
+    setLeague(league);
+  });
+</script>
+
+<Card class="items-center">
+  {#if $league}
+    <Avatar src={rankImage + $league.tier.toLowerCase() + rankImageFormat} size="lg" border rounded></Avatar>
+  {/if}
+</Card>

--- a/src/lib/interfaces/LeagueEntryDto.ts
+++ b/src/lib/interfaces/LeagueEntryDto.ts
@@ -1,0 +1,14 @@
+export default interface LeagueEntryDto {
+  leagueId: string;
+  summonerId: string;
+  queueType: string;
+  tier: string;
+  rank: string;
+  leaguePoints: number;
+  wins: number;
+  losses: number;
+  hotStreak: boolean;
+  veteran: boolean;
+  freshBlood: boolean;
+  inactive: boolean;
+}

--- a/src/lib/interfaces/RegionId.ts
+++ b/src/lib/interfaces/RegionId.ts
@@ -1,0 +1,7 @@
+import type Region from './Region';
+
+enum RegionId {
+  JP1 = 'JP1'
+}
+
+export default RegionId;

--- a/src/lib/interfaces/SummonerDto.ts
+++ b/src/lib/interfaces/SummonerDto.ts
@@ -1,0 +1,8 @@
+export default interface SummonerDto {
+  accountId: string;
+  profileIconId: number;
+  revisionDate: string;
+  id: string;
+  puuid: string;
+  summonerLevel: string;
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -3,9 +3,7 @@
 </script>
 
 <main>
-  <div class="search-bar">
     <SearchBar></SearchBar>
-  </div>
 </main>
 
 <style>

--- a/src/routes/accounts/[region]/[gameName]/[tagLine]/+page.svelte
+++ b/src/routes/accounts/[region]/[gameName]/[tagLine]/+page.svelte
@@ -1,16 +1,38 @@
 <script lang="ts">
-  import type RiotLolAccount from '$lib/interfaces/RiotLolAccount.js';
-  import { onDestroy } from 'svelte';
+  import SearchBar from '$lib/components/SearchBar.svelte';
+  import SummonerCard from '$lib/components/SummonerCard.svelte';
+  import SummonerCardElo from '$lib/components/SummonerCardElo.svelte';
+  import type LeagueEntryDto from '$lib/interfaces/LeagueEntryDto.js';
+  import type SummonerDto from '$lib/interfaces/SummonerDto.js';
+  import { Spinner } from 'flowbite-svelte';
+  import { writable, type Writable } from 'svelte/store';
 
   export let data;
 
-  let account: RiotLolAccount | null;
+  $: account = data['data'];
+  $: summoner = writable<SummonerDto | null>(null);
+  $: league = writable<LeagueEntryDto | null>(null);
 
-  const unsubscribe = data.data.subscribe((value) => {
-    account = value;
-  });
+  const { isLoading, error } = data;
 
-  onDestroy(unsubscribe);
+  const setSummoner = (param: Writable<SummonerDto | null>) => {
+    summoner = param;
+  };
+
+  const setLeague = (param: Writable<LeagueEntryDto | null>) => {
+    league = param;
+  };
 </script>
 
-<div>{JSON.stringify(account)}</div>
+<SearchBar></SearchBar>
+
+<div class="flex flex-col items-center p-5 gap-5">
+  {#if $isLoading}
+    <Spinner color="gray" />
+  {:else if $account}
+    <SummonerCard account={$account} {setSummoner}></SummonerCard>
+    {#if $summoner}
+      <SummonerCardElo summoner={$summoner} {setLeague}></SummonerCardElo>
+    {/if}
+  {/if}
+</div>


### PR DESCRIPTION
modified: src/routes/accounts/[region]/[gameName]/[tagLine]/+page.svelte
-> export let data - receives data from the page loader (+page.ts).
-> after fetching the account data, the summoner info is fetched.
-> using SummonerCard and SummonerCardElo to display the summoner data.
-> $: account = data['data']; - used to refresh the data after a new
account is searched.
modified:   src/routes/+page.svelte -> removed unnecessary div.
<---->
new file:   src/lib/components/SummonerCard.svelte
new file:   src/lib/components/SummonerCardElo.svelte
new file:   src/lib/interfaces/LeagueEntryDto.ts
new file:   src/lib/interfaces/RegionId.ts
new file:   src/lib/interfaces/SummonerDto.ts
<---->
-> interfaces to match the backend response
modified:   src/lib/components/SearchBar.svelte
-> removed unnecessary onMount function.
-> new div container.
new file:   src/lib/api/summoner.ts -> useFetchSummoner - To fetch the
summoner data. Using writables to pass to the caller the fetch
information.
new file:   src/lib/api/league.ts -> useFetchLeague - Same as
useFetchSummoner but to fetch the league stats.